### PR TITLE
Changed ProcessWrap.StartInfo property so that …

### DIFF
--- a/SystemWrapper.Tests/Diagnostics/ProcessWrapTests.cs
+++ b/SystemWrapper.Tests/Diagnostics/ProcessWrapTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using SystemInterface.Diagnostics;
 using SystemWrapper.Diagnostics;
 using NUnit.Framework;
 using Rhino.Mocks;
@@ -41,6 +43,25 @@ namespace SystemWrapper.Tests.IO
             Assert.AreNotSame(origInfo, instance.ProcessInstance);
             Assert.IsNotNull(instance.ProcessInstance);
             Assert.IsNotNull(instance.StandardOutput);
+        }
+
+        [Test]
+        public void StartInfo_Set_AssignsStartInfoWrap()
+        {
+            // Arrange
+            var mockProcessStartInfoWrap = MockRepository.GenerateMock<IProcessStartInfo>();
+            var processStartInfo = new ProcessStartInfo(); // Can't mock, so going to use the actual thing.
+            mockProcessStartInfoWrap.Stub(x => x.ProcessStartInfoInstance).Return(processStartInfo);
+            var instance = new ProcessWrap();
+            instance.Initialize();
+
+            // Act
+            instance.StartInfo = mockProcessStartInfoWrap;
+
+            // Assert
+            Assert.AreEqual(mockProcessStartInfoWrap, instance.StartInfo);
+            Assert.AreEqual(processStartInfo, instance.StartInfo.ProcessStartInfoInstance);
+            Assert.AreEqual(processStartInfo, instance.ProcessInstance.StartInfo);
         }
     }
 }

--- a/SystemWrapper/Diagnostics/ProcessWrap.cs
+++ b/SystemWrapper/Diagnostics/ProcessWrap.cs
@@ -57,7 +57,11 @@ namespace SystemWrapper.Diagnostics
         public IProcessStartInfo StartInfo
         {
             get { return this._startInfo ?? (this._startInfo = new ProcessStartInfoWrap(ProcessInstance.StartInfo)); }
-            set { this._startInfo = value; }
+            set
+            {
+                this._startInfo = value;
+                ProcessInstance.StartInfo = _startInfo.ProcessStartInfoInstance;
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
…ProcessInstance.StartInfo is assigned the ProcessStartInfoInstance of the passed in IProcessStartInfo. Added associated tests.

Reason for change is because ProcessWrap.Start() calls Start() on the ProcessInstance, which doesn't have any process start info.