### PR TITLE
Added link to NuGet badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # SystemWrapper
 
-![NuGet version](https://img.shields.io/nuget/v/SystemWrapper.Interfaces.svg) ![branch: master](http://img.shields.io/badge/branch-master-blue.svg?style=flat) [![Build status: master](https://ci.appveyor.com/api/projects/status/1126fol0d56a8my8/branch/master?svg=true)](https://ci.appveyor.com/project/jozefizso/systemwrapper/branch/master) ° ![branch: master](http://img.shields.io/badge/branch-develop-blue.svg?style=flat) [![Build status: develop](https://ci.appveyor.com/api/projects/status/1126fol0d56a8my8/branch/develop?svg=true)](https://ci.appveyor.com/project/jozefizso/systemwrapper/branch/develop)
+[![NuGet version](https://img.shields.io/nuget/v/SystemWrapper.Interfaces.svg)](https://www.nuget.org/packages/SystemWrapper.Wrappers/)
+![branch: master](http://img.shields.io/badge/branch-master-blue.svg?style=flat) [![Build status: master](https://ci.appveyor.com/api/projects/status/1126fol0d56a8my8/branch/master?svg=true)](https://ci.appveyor.com/project/jozefizso/systemwrapper/branch/master) ° ![branch: master](http://img.shields.io/badge/branch-develop-blue.svg?style=flat) [![Build status: develop](https://ci.appveyor.com/api/projects/status/1126fol0d56a8my8/branch/develop?svg=true)](https://ci.appveyor.com/project/jozefizso/systemwrapper/branch/develop)
 
 > **SystemWrapper** is .NET library for easier testing of system APIs.
 


### PR DESCRIPTION
Added the badge, linking to https://www.nuget.org/packages/SystemWrapper.Wrappers/

before clicking on badge showed:

![image](https://user-images.githubusercontent.com/5808377/33743728-55bd6438-dbae-11e7-9d71-ce55de3b798b.png)
