### PR TITLE
IDateTime: implement IEquatable<>, IComparable<> and IComparable

### DIFF
--- a/SystemInterface/IDateTime.cs
+++ b/SystemInterface/IDateTime.cs
@@ -8,7 +8,7 @@ namespace SystemInterface
     /// <summary>
     /// Wrapper for <see cref="System.DateTime"/> class.
     /// </summary>
-    public interface IDateTime : IEquatable<IDateTime>, IComparable<IDateTime>
+    public interface IDateTime : IEquatable<IDateTime>, IComparable<IDateTime>, IComparable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="T:SystemInterface.DateTimeWrap"/> class.
@@ -297,13 +297,6 @@ namespace SystemInterface
         /// <param name="t2">The second IDateTimeWrap. </param>
         /// <returns>A signed number indicating the relative values of t1 and t2.</returns>
         int Compare(IDateTime t1, IDateTime t2);
-
-        /// <summary>
-        /// Compares the value of this instance to a specified object that contains a specified IDateTimeWrap value, and returns an integer that indicates whether this instance is earlier than, the same as, or later than the specified IDateTimeWrap value.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        int CompareTo(object value);
 
         /// <summary>
         /// Returns the number of days in the specified month and year.

--- a/SystemInterface/IDateTime.cs
+++ b/SystemInterface/IDateTime.cs
@@ -8,7 +8,7 @@ namespace SystemInterface
     /// <summary>
     /// Wrapper for <see cref="System.DateTime"/> class.
     /// </summary>
-    public interface IDateTime
+    public interface IDateTime : IEquatable<IDateTime>, IComparable<IDateTime>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="T:SystemInterface.DateTimeWrap"/> class.
@@ -299,13 +299,6 @@ namespace SystemInterface
         int Compare(IDateTime t1, IDateTime t2);
 
         /// <summary>
-        /// Compares the value of this instance to a specified IDateTimeWrap value and returns an integer that indicates whether this instance is earlier than, the same as, or later than the specified IDateTimeWrap value.
-        /// </summary>
-        /// <param name="value">A IDateTimeWrap object to compare. </param>
-        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
-        int CompareTo(IDateTime value);
-
-        /// <summary>
         /// Compares the value of this instance to a specified object that contains a specified IDateTimeWrap value, and returns an integer that indicates whether this instance is earlier than, the same as, or later than the specified IDateTimeWrap value.
         /// </summary>
         /// <param name="value"></param>
@@ -319,14 +312,7 @@ namespace SystemInterface
         /// <param name="month">The month (a number ranging from 1 to 12). </param>
         /// <returns>The number of days in month for the specified year.</returns>
         int DaysInMonth(int year, int month);
-
-        /// <summary>
-        /// Returns a value indicating whether this instance is equal to the specified IDateTimeWrap instance.
-        /// </summary>
-        /// <param name="value">A IDateTimeWrap instance to compare to this instance. </param>
-        /// <returns> <c>true</c> if the value parameter equals the value of this instance; otherwise, false.</returns>
-        bool Equals(IDateTime value);
-
+        
         /// <summary>
         /// Returns a value indicating whether two instances of IDateTimeWrap are equal.
         /// </summary>

--- a/SystemWrapper.Tests/DateTimeWrapTests.cs
+++ b/SystemWrapper.Tests/DateTimeWrapTests.cs
@@ -1,14 +1,14 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 using SystemInterface;
 
 namespace SystemWrapper.Tests
 {
-    [TestClass]
+    [TestFixture]
     public class DateTimeWrapTests
     {
         const long dateTicks = 636846612300000000L;
 
-        [TestMethod]
+        [Test]
         public void Equatable_SameDateTime()
         {
             IDateTime date1 = new DateTimeWrap(dateTicks);
@@ -21,7 +21,7 @@ namespace SystemWrapper.Tests
             Assert.AreEqual(date1.GetHashCode(), date2.GetHashCode());
         }
 
-        [TestMethod]
+        [Test]
         public void Equatable_DifferentDateTime()
         {
             var date1 = new DateTimeWrap(dateTicks);
@@ -33,7 +33,7 @@ namespace SystemWrapper.Tests
             Assert.AreNotEqual(date1, dateObject);
         }
         
-        [TestMethod]
+        [Test]
         public void Comparable_SameDateTime()
         {
             IDateTime date1 = new DateTimeWrap(dateTicks);
@@ -45,7 +45,7 @@ namespace SystemWrapper.Tests
             Assert.AreEqual(date1.CompareTo(dateObject), 0);
         }
 
-        [TestMethod]
+        [Test]
         public void Comparable_DifferentDateTime()
         {
             IDateTime date = new DateTimeWrap(dateTicks);

--- a/SystemWrapper.Tests/DateTimeWrapTests.cs
+++ b/SystemWrapper.Tests/DateTimeWrapTests.cs
@@ -32,5 +32,30 @@ namespace SystemWrapper.Tests
             Assert.AreNotEqual(date1, date2);
             Assert.AreNotEqual(date1, dateObject);
         }
+        
+        [TestMethod]
+        public void Comparable_SameDateTime()
+        {
+            IDateTime date1 = new DateTimeWrap(dateTicks);
+            IDateTime date2 = new DateTimeWrap(dateTicks);
+            object dateObject = new DateTimeWrap(dateTicks);
+
+            Assert.AreEqual(0, date1.CompareTo(date1));
+            Assert.AreEqual(0, date1.CompareTo(date2));
+            Assert.AreEqual(date1.CompareTo(dateObject), 0);
+        }
+
+        [TestMethod]
+        public void Comparable_DifferentDateTime()
+        {
+            IDateTime date = new DateTimeWrap(dateTicks);
+            IDateTime laterDate = new DateTimeWrap(dateTicks + 1);
+            object laterDateObject = new DateTimeWrap(dateTicks + 1);
+
+            Assert.AreEqual(1, date.CompareTo(null));
+            Assert.AreEqual(-1, date.CompareTo(laterDate));
+            Assert.AreEqual(1, laterDate.CompareTo(date));
+            Assert.AreEqual(-1, date.CompareTo(laterDateObject));
+        }
     }
 }

--- a/SystemWrapper.Tests/DateTimeWrapTests.cs
+++ b/SystemWrapper.Tests/DateTimeWrapTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SystemInterface;
+
+namespace SystemWrapper.Tests
+{
+    [TestClass]
+    public class DateTimeWrapTests
+    {
+        const long dateTicks = 636846612300000000L;
+
+        [TestMethod]
+        public void Equatable_SameDateTime()
+        {
+            IDateTime date1 = new DateTimeWrap(dateTicks);
+            IDateTime date2 = new DateTimeWrap(dateTicks);
+            object dateObject = new DateTimeWrap(dateTicks);
+
+            Assert.AreEqual(date1, date1);
+            Assert.AreEqual(date1, date2);
+            Assert.AreEqual(date1, dateObject);
+            Assert.AreEqual(date1.GetHashCode(), date2.GetHashCode());
+        }
+
+        [TestMethod]
+        public void Equatable_DifferentDateTime()
+        {
+            var date1 = new DateTimeWrap(dateTicks);
+            var date2 = new DateTimeWrap(dateTicks + 1L);
+            object dateObject = new DateTimeWrap(dateTicks + 1L);
+
+            Assert.AreNotEqual(date1, null);
+            Assert.AreNotEqual(date1, date2);
+            Assert.AreNotEqual(date1, dateObject);
+        }
+    }
+}

--- a/SystemWrapper.Tests/SystemWrapper.Tests.csproj
+++ b/SystemWrapper.Tests/SystemWrapper.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Data\SqlClient\SqlCommandWrapTests.cs" />
     <Compile Include="Data\SqlClient\SqlConnectionWrapTests.cs" />
     <Compile Include="Data\SqlClient\SqlDataReaderWrapTests.cs" />
+    <Compile Include="DateTimeWrapTests.cs" />
     <Compile Include="Diagnostics\FileVersionInfoFactoryTests.cs" />
     <Compile Include="Diagnostics\FileVersionInfoWrapTests.cs" />
     <Compile Include="Diagnostics\ProcessStartInfoWrapTests.cs" />

--- a/SystemWrapper/DateTimeWrap.cs
+++ b/SystemWrapper/DateTimeWrap.cs
@@ -515,13 +515,19 @@ namespace SystemWrapper
         /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
         public int CompareTo(IDateTime value)
         {
-            return DateTimeInstance.CompareTo(value.DateTimeInstance);
+            return value == null ? 
+                DateTimeInstance.CompareTo(value) :
+                DateTimeInstance.CompareTo(value.DateTimeInstance);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Compares the value of this instance to a specified object that contains a specified IDateTimeWrap value, and returns an integer that indicates whether this instance is earlier than, the same as, or later than the specified IDateTimeWrap value.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public int CompareTo(object value)
         {
-            return DateTimeInstance.CompareTo(value);
+            return CompareTo(value as DateTimeWrap);
         }
 
         /// <inheritdoc />

--- a/SystemWrapper/DateTimeWrap.cs
+++ b/SystemWrapper/DateTimeWrap.cs
@@ -508,7 +508,11 @@ namespace SystemWrapper
             return DateTime.Compare(t1.DateTimeInstance, t2.DateTimeInstance);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Compares the value of this instance to a specified IDateTimeWrap value and returns an integer that indicates whether this instance is earlier than, the same as, or later than the specified IDateTimeWrap value.
+        /// </summary>
+        /// <param name="value">A IDateTimeWrap object to compare. </param>
+        /// <returns>A signed number indicating the relative values of this instance and the value parameter.</returns>
         public int CompareTo(IDateTime value)
         {
             return DateTimeInstance.CompareTo(value.DateTimeInstance);
@@ -526,16 +530,23 @@ namespace SystemWrapper
             return DateTime.DaysInMonth(year, month);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns a value indicating whether this instance is equal to the specified IDateTimeWrap instance.
+        /// </summary>
+        /// <param name="value">A IDateTimeWrap instance to compare to this instance. </param>
+        /// <returns> <c>true</c> if the value parameter equals the value of this instance; otherwise, false.</returns>
         public bool Equals(IDateTime value)
         {
-            return DateTimeInstance.Equals(value);
+            return value != null && DateTimeInstance.Equals(value.DateTimeInstance);
         }
 
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
-            return DateTimeInstance.Equals(obj);
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((IDateTime)obj);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
I ran into an issue whereby an `IDateTime` isn't equal to itself, causing issues when using dictionaries, etc. This is [a known issue](https://github.com/jozefizso/SystemWrapper/issues/48). The change below adds support for comparison and equality. 

I wasn't quite sure what test framework to use. I went with MS Tests, but can change to NUnit if preferred.