### PR TITLE
Add CreateNoWindow to IProcessStartInfo

### DIFF
--- a/SystemInterface/Diagnostics/IProcessStartInfo.cs
+++ b/SystemInterface/Diagnostics/IProcessStartInfo.cs
@@ -51,6 +51,11 @@ namespace SystemInterface.Diagnostics
         bool UseShellExecute { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to start the process in a new window
+        /// </summary>
+        bool CreateNoWindow { get; set; }
+
+        /// <summary>
         /// Gets or sets a value that indicates whether the output of an application is written to
         /// the <see cref="IProcess.StandardOutput"/> stream.
         /// </summary>

--- a/SystemWrapper/Diagnostics/ProcessStartInfoWrap.cs
+++ b/SystemWrapper/Diagnostics/ProcessStartInfoWrap.cs
@@ -104,6 +104,13 @@ namespace SystemWrapper.Diagnostics
         }
 
         /// <inheritdoc />
+        public bool CreateNoWindow
+        {
+            get { return ProcessStartInfoInstance.CreateNoWindow; }
+            set { ProcessStartInfoInstance.CreateNoWindow = value; }
+        }
+
+        /// <inheritdoc />
         public bool RedirectStandardOutput
         {
             get { return ProcessStartInfoInstance.RedirectStandardOutput; }


### PR DESCRIPTION
- add the missing CreateNoWindow property to IProcessStartInfo in order to avoid using the ProcessStartInfoInstance property 
- did not write a unit test for it, because there where no tests for plain getters/setters existing in the ProcessStartInfoWrap (just let me know if you need a test)
